### PR TITLE
Watch for changes in the elements of the options & selection array

### DIFF
--- a/addon/components/multiselect-checkboxes.js
+++ b/addon/components/multiselect-checkboxes.js
@@ -35,7 +35,7 @@ export default Ember.Component.extend({
 
   disabled: false,
 
-  checkboxes: Ember.computed('options', 'labelProperty', 'valueProperty', 'selection', function () {
+  checkboxes: Ember.computed('options.[]', 'labelProperty', 'valueProperty', 'selection.[]', function () {
     let labelProperty = this.get('labelProperty');
     let valueProperty = this.get('valueProperty');
     let selection = Ember.A(this.get('selection'));

--- a/tests/unit/components/multiselect-checkboxes-test.js
+++ b/tests/unit/components/multiselect-checkboxes-test.js
@@ -36,6 +36,13 @@ test('uses the correct labels with primitive values and no label property', func
   assert.equal($(labels[0]).text().trim(), 'apple');
   assert.equal($(labels[1]).text().trim(), 'orange');
   assert.equal($(labels[2]).text().trim(), 'strawberry');
+
+  Ember.run(() => fruits.reverseObjects());
+  labels = this.$().find('label');
+  assert.equal($(labels[0]).text().trim(), 'strawberry');
+  assert.equal($(labels[1]).text().trim(), 'orange');
+  assert.equal($(labels[2]).text().trim(), 'apple');
+
 });
 
 test('uses the correct labels with plain js values and a label property', function (assert) {
@@ -72,10 +79,11 @@ test('uses the correct labels with Ember object values and a label property', fu
 
 test('checks the checkboxes that represent a value currently in the selection', function (assert) {
   let component = this.subject();
+  let selection = Ember.A([persons[0], persons[2]]);
 
   Ember.run(() => component.setProperties({
     'options': persons,
-    'selection': Ember.A([persons[0], persons[2]]),
+    'selection': selection,
     'labelProperty': 'name'
   }));
 
@@ -84,6 +92,14 @@ test('checks the checkboxes that represent a value currently in the selection', 
   assert.equal($(labels[0]).find('input[type="checkbox"]').prop('checked'), true);
   assert.equal($(labels[1]).find('input[type="checkbox"]').prop('checked'), false);
   assert.equal($(labels[2]).find('input[type="checkbox"]').prop('checked'), true);
+
+  Ember.run(() => selection.removeObject(persons[0]));
+
+  labels = this.$().find('label');
+  assert.equal($(labels[0]).find('input[type="checkbox"]').prop('checked'), false);
+  assert.equal($(labels[1]).find('input[type="checkbox"]').prop('checked'), false);
+  assert.equal($(labels[2]).find('input[type="checkbox"]').prop('checked'), true);
+
 });
 
 test('adds the value a checkbox represents to the selection when that checkbox is checked', function (assert) {


### PR DESCRIPTION
In my use case, I am sourcing the the options and selections from ember data which returns promises.

Hence, changing the `computed` function to detect changes in the elements of the array, rather than the array itself. 