### PR TITLE
Upgrade Ember and Friends to 2.8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,22 +13,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.js]
-indent_style = space
-indent_size = 2
-
 [*.hbs]
 insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.css]
-indent_style = space
-indent_size = 2
-
-[*.html]
-indent_style = space
-indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false

--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ matrix:
 before_install:
   - npm config set spin false
   - npm install -g bower
+  - bower --version
   - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - npm install
@@ -33,4 +35,4 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/addon/components/multiselect-checkboxes.js
+++ b/addon/components/multiselect-checkboxes.js
@@ -3,12 +3,12 @@ import Ember from 'ember';
 let Checkbox = Ember.Object.extend({
   isSelected: Ember.computed('value', 'selection.[]', {
     get() {
-      return this.get('selection').contains(this.get('value'));
+      return this.get('selection').includes(this.get('value'));
     },
 
     set(_, checked) {
       let selection = this.get('selection');
-      let selected = selection.contains(this.get('value'));
+      let selected = selection.includes(this.get('value'));
       let onchange = this.get('onchange');
       let updateSelectionValue = this.get('updateSelectionValue');
       let isMutable = typeof selection.addObject === 'function' && typeof selection.removeObject === 'function';

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,7 @@
 {
   "name": "ember-multiselect-checkboxes",
   "dependencies": {
-    "ember": "~2.6.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
+    "ember": "~2.8.0",
+    "ember-cli-shims": "0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ember-multiselect-checkboxes",
   "version": "0.10.0",
+  "description": "Simple Ember component for allowing multiple selection from a certain collection (a hasMany property for example) using checkboxes.",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -19,18 +20,19 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
-    "ember-cli": "2.6.2",
+    "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^1.4.0",
+    "ember-cli-qunit": "^2.1.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.6.0",
+    "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-i18n": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-i18n": "4.2.2",
+    "ember-i18n": "4.3.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^1.0.1",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -47,6 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function () {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     i18n: {
       defaultLocale: 'es'
@@ -32,7 +32,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/tests/integration/multiselect-checkboxes-test.js
+++ b/tests/integration/multiselect-checkboxes-test.js
@@ -131,7 +131,7 @@ test('adds the value a checkbox represents to the selection when that checkbox i
 
   assert.equal($(checkboxes[2]).prop('checked'), true);
   assert.equal(this.get('selection.length'), 2);
-  assert.equal(this.get('selection').contains(persons[2]), true);
+  assert.equal(this.get('selection').includes(persons[2]), true);
 });
 
 test('removes the value a checkbox represents from the selection when that checkbox is unchecked', function (assert) {
@@ -152,7 +152,7 @@ test('removes the value a checkbox represents from the selection when that check
 
   assert.equal($(checkboxes[0]).prop('checked'), false);
   assert.equal(this.get('selection.length'), 0);
-  assert.equal(this.get('selection').contains(persons[0]), false);
+  assert.equal(this.get('selection').includes(persons[0]), false);
 });
 
 test('triggers the onchange action with the correct arguments when the selection changes', function (assert) {
@@ -162,7 +162,7 @@ test('triggers the onchange action with the correct arguments when the selection
     'actions': {
       updateSelection: (newSelection, value, operation) => {
         assert.equal(newSelection.length, 1);
-        assert.equal(newSelection.contains(persons[1]), true);
+        assert.equal(newSelection.includes(persons[1]), true);
         assert.equal(value, persons[1]);
         assert.equal(operation, 'added');
       }
@@ -193,8 +193,8 @@ test('does not update the bound selection value when updateSelectionValue is set
   $(checkboxes[1]).click();
 
   assert.equal(this.get('selection.length'), 1);
-  assert.equal(this.get('selection').contains(persons[0]), true);
-  assert.equal(this.get('selection').contains(persons[1]), false);
+  assert.equal(this.get('selection').includes(persons[0]), true);
+  assert.equal(this.get('selection').includes(persons[1]), false);
 });
 
 test('checks the correct options with plain js values and a value property', function (assert) {
@@ -232,8 +232,8 @@ test('updates the selection correctly with plain js values and a value property'
 
   assert.equal($(checkboxes[0]).prop('checked'), true);
   assert.equal(this.get('selection.length'), 2);
-  assert.equal(this.get('selection').contains('black'), true);
-  assert.equal(this.get('selection').contains('red'), true);
+  assert.equal(this.get('selection').includes('black'), true);
+  assert.equal(this.get('selection').includes('red'), true);
 });
 
 test('checks the correct options with Ember object values and a value property', function (assert) {
@@ -272,8 +272,8 @@ test('updates the selection correctly with Ember object values and a value prope
   assert.equal($(checkboxes[0]).prop('checked'), true);
 
   assert.equal(this.get('selection.length'), 2);
-  assert.equal(this.get('selection').contains('Lisa'), true);
-  assert.equal(this.get('selection').contains('Bob'), true);
+  assert.equal(this.get('selection').includes('Lisa'), true);
+  assert.equal(this.get('selection').includes('Bob'), true);
 });
 
 test('disables all checkboxes when disabled is set to true', function (assert) {
@@ -297,7 +297,7 @@ test('disables all checkboxes when disabled is set to true', function (assert) {
   });
 
   assert.equal(this.get('selection.length'), 1);
-  assert.equal(this.get('selection').contains(persons[0]), true);
+  assert.equal(this.get('selection').includes(persons[0]), true);
 });
 
 test('updates the displayed options when the bound options change', function (assert) {
@@ -395,5 +395,5 @@ test('with a template block adds the value a checkbox represents to the selectio
 
   assert.equal($(checkboxes[2]).prop('checked'), true);
   assert.equal(this.get('selection.length'), 1);
-  assert.equal(this.get('selection').contains(persons[2]), true);
+  assert.equal(this.get('selection').includes(persons[2]), true);
 });


### PR DESCRIPTION
This, along with upgrading Ember and friends to 2.8, silences deprecation warnings for people using modern Ember.

It'd be lovely to have this cut as part of a release when it's accepted.