### PR TITLE
lazy-load `i18n` service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,14 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-release-without-i18n
+  - EMBER_TRY_SCENARIO=ember-canary-without-i18n
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-canary-without-i18n
 
 before_install:
   - npm config set spin false

--- a/addon/components/multiselect-checkboxes.js
+++ b/addon/components/multiselect-checkboxes.js
@@ -54,7 +54,9 @@ export default Ember.Component.extend({
 
   tagName: 'ul',
 
-  i18n: Ember.inject.service('i18n'),
+  i18n: Ember.computed(function () {
+    return Ember.getOwner(this).lookup('service:i18n');
+  }),
 
   checkboxes: Ember.computed('options.[]', 'labelProperty', 'valueProperty', 'selection', 'translate', function () {
     let labelProperty = this.get('labelProperty');

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -30,6 +30,22 @@ module.exports = {
       }
     },
     {
+      name: 'ember-release-without-i18n',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-i18n': null
+        }
+      },
+    },
+    {
       name: 'ember-beta',
       bower: {
         dependencies: {
@@ -50,6 +66,22 @@ module.exports = {
           'ember': 'canary'
         }
       }
+    },
+    {
+      name: 'ember-canary-without-i18n',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#canary'
+        },
+        resolutions: {
+          'ember': 'canary'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-i18n': null
+        }
+      },
     }
   ]
 };

--- a/tests/integration/multiselect-checkboxes-test.js
+++ b/tests/integration/multiselect-checkboxes-test.js
@@ -1,6 +1,7 @@
 import hbs from 'htmlbars-inline-precompile';
 import { test, moduleForComponent } from 'ember-qunit';
 import Ember from 'ember';
+import { has } from 'require';
 
 moduleForComponent('multiselect-checkboxes', 'Multiselect checkboxes component', {
   integration: true
@@ -54,19 +55,21 @@ test('uses the correct labels with plain js values and a label property', functi
   assert.equal($(labels[2]).text().trim(), 'Volvo');
 });
 
-test('labels are translated when translate is true and i18n addon is present', function (assert) {
-  this.set('options', persons);
+if(has('ember-i18n')) {
+  test('labels are translated when translate is true and i18n addon is present', function (assert) {
+    this.set('options', persons);
 
-  this.render(hbs`
-    {{multiselect-checkboxes options=options labelProperty='name' translate=true}}
-  `);
+    this.render(hbs`
+      {{multiselect-checkboxes options=options labelProperty='name' translate=true}}
+    `);
 
-  let labels = this.$('label');
+    let labels = this.$('label');
 
-  assert.equal($(labels[0]).text().trim(), 'Luisa');
-  assert.equal($(labels[1]).text().trim(), 'Roberto');
-  assert.equal($(labels[2]).text().trim(), 'Juan');
-});
+    assert.equal($(labels[0]).text().trim(), 'Luisa');
+    assert.equal($(labels[1]).text().trim(), 'Roberto');
+    assert.equal($(labels[2]).text().trim(), 'Juan');
+  });
+}
 
 test('labels are not translated when translate is true and i18n addon is not present', function (assert) {
   this.set('options', persons);


### PR DESCRIPTION
`i18n: Ember.inject.service('i18n')` fails in ember canary when the `ember-i18n` addon isn't available with an `Attempting to inject an unknown injection: 'service:i18n'` error. It seems that a bug was recently fixed in Ember as looking up a missing service was always meant to be a runtime error.

TODO:

 * [x] add ember-try configuration scenarios which demonstrate the failing tests
 * [x] update to use `i18n: Ember.computed(function () { return Ember.getOwner(this).lookup('service:i18n'); })`

/cc @RSSchermer