### PR TITLE
fix: hasBlock helper deprecated in favour of has-block

### DIFF
--- a/addon/templates/components/multiselect-checkboxes.hbs
+++ b/addon/templates/components/multiselect-checkboxes.hbs
@@ -1,5 +1,5 @@
 {{#each checkboxes as |checkbox index|}}
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{yield checkbox.option checkbox.isSelected index}}
   {{else}}
     <li>


### PR DESCRIPTION
[Deprecation reference](https://deprecations.emberjs.com/v3.x#toc_has-block-and-has-block-params)